### PR TITLE
Support for internal navigation and resource loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ out
 dist
 node_modules
 .vscode-test/
+.vs/
 *.vsix
 obj
 bin

--- a/blazorApp/Pages/FetchData.razor
+++ b/blazorApp/Pages/FetchData.razor
@@ -1,6 +1,5 @@
 ﻿@page "/fetchdata"
 @inject HttpClient Http
-@inject VsCodeHelper VsCode
 
 <PageTitle>Weather forecast</PageTitle>
 
@@ -42,8 +41,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var requestUri = VsCode.AsWebViewUri("sample-data/weather.json");
-        forecasts = await Http.GetFromJsonAsync<WeatherForecast[]>(requestUri);
+        forecasts = await Http.GetFromJsonAsync<WeatherForecast[]>("sample-data/weather.json");
     }
 
     public class WeatherForecast

--- a/blazorApp/Pages/FetchData.razor
+++ b/blazorApp/Pages/FetchData.razor
@@ -1,5 +1,6 @@
 ﻿@page "/fetchdata"
 @inject HttpClient Http
+@inject VsCodeHelper VsCode
 
 <PageTitle>Weather forecast</PageTitle>
 
@@ -41,7 +42,8 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        forecasts = await Http.GetFromJsonAsync<WeatherForecast[]>("sample-data/weather.json");
+        var requestUri = VsCode.AsWebViewUri("sample-data/weather.json");
+        forecasts = await Http.GetFromJsonAsync<WeatherForecast[]>(requestUri);
     }
 
     public class WeatherForecast

--- a/blazorApp/Program.cs
+++ b/blazorApp/Program.cs
@@ -1,11 +1,19 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using blazorApp;
+using blazorApp.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped<HttpClient>();
+builder.Services.AddSingleton<VsCodeHelper>();
 
-await builder.Build().RunAsync();
+var host = builder.Build();
+
+// Perform VSCode-specific setup before running the host.
+var vsCodeHelper = host.Services.GetRequiredService<VsCodeHelper>();
+vsCodeHelper.Initialize();
+
+await host.RunAsync();

--- a/blazorApp/Program.cs
+++ b/blazorApp/Program.cs
@@ -7,8 +7,16 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped<HttpClient>();
 builder.Services.AddSingleton<VsCodeHelper>();
+builder.Services.AddScoped<HttpClient>(sp =>
+{
+    var vsCodeHelper = sp.GetRequiredService<VsCodeHelper>();
+    var localResourceRoot = vsCodeHelper.AsWebViewResourceFileUri(relativeUri: "");
+    return new()
+    {
+        BaseAddress = new(localResourceRoot),
+    };
+});
 
 var host = builder.Build();
 

--- a/blazorApp/Services/VsCodeHelper.cs
+++ b/blazorApp/Services/VsCodeHelper.cs
@@ -1,0 +1,127 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.JSInterop;
+using System.Collections.Specialized;
+using System.Web;
+
+namespace blazorApp.Services;
+
+internal sealed class VsCodeHelper : IDisposable
+{
+    private const string GetLocalResourceRootJsMethod = "getLocalResourceRoot";
+
+    private readonly IJSInProcessRuntime _jsInProcessRuntime;
+    private readonly NavigationManager _navigationManager;
+
+    private NameValueCollection _requiredQueryParameters = default!;
+    private IDisposable _locationChangingRegistration = default!;
+    private string _localResourceRoot = default!;
+
+    private bool _isInitialized;
+
+    public VsCodeHelper(IJSRuntime jsRuntime, NavigationManager navigationManager)
+    {
+        if (jsRuntime is not IJSInProcessRuntime jsInProcessRuntime)
+        {
+            throw new InvalidOperationException(
+                $"The {nameof(VsCodeHelper)} service requires a '{nameof(IJSInProcessRuntime)}' " +
+                $"but got a '{jsRuntime.GetType().Name}' instead.");
+        }
+
+        _jsInProcessRuntime = jsInProcessRuntime;
+        _navigationManager = navigationManager;
+    }
+
+    public void Initialize()
+    {
+        if (_isInitialized)
+        {
+            return;
+        }
+
+        var uriString = _navigationManager.Uri;
+        if (!Uri.TryCreate(uriString, UriKind.RelativeOrAbsolute, out var uri))
+        {
+            throw new InvalidOperationException($"Could not parse the URI '{uriString}'.");
+        }
+
+        if (uri.Query is not { Length: > 0 } queryString)
+        {
+            throw new InvalidOperationException($"The required query string was empty.");
+        }
+
+        _requiredQueryParameters = HttpUtility.ParseQueryString(queryString);
+
+        // VSCode navigates to /index.html by default, which will match the "not found" route
+        // after Blazor starts up. So, we navigate to the home page immediately.
+        _navigationManager.NavigateTo($"/?{_requiredQueryParameters}");
+
+        // VSCode reads query parameters from the URI to determine how to load resources. Since
+        // navigations would remove that query string, we intercept all navigation attempts,
+        // cancelling them if they don't have the required query parameters. We then re-initiate the navigation
+        // with the required query parameters.
+        _locationChangingRegistration = _navigationManager.RegisterLocationChangingHandler(HandleLocationChangingAsync);
+
+        // Local resources have URIs with an external origin, so relative paths must be converted to have that origin.
+        // We use JS interop to invoke a method that returns the local resource root to help perform this conversion.
+        _localResourceRoot = _jsInProcessRuntime.Invoke<string>(GetLocalResourceRootJsMethod);
+
+        _isInitialized = true;
+    }
+
+    public string AsWebViewUri(string relativeUri)
+    {
+        AssertInitialized();
+        return Path.Combine(_localResourceRoot, relativeUri);
+    }
+
+    private ValueTask HandleLocationChangingAsync(LocationChangingContext context)
+    {
+        if (!Uri.TryCreate(context.TargetLocation, UriKind.RelativeOrAbsolute, out var uri))
+        {
+            // Don't attempt to manipulate malformed URIs.
+            return ValueTask.CompletedTask;
+        }
+
+        var queryParameters = HttpUtility.ParseQueryString(uri.Query);
+
+        // "id" is just one of the required query parameters. For simplicity,
+        // we're assuming that URIs either have all or none of the required parameters.
+        if (queryParameters["id"] is null)
+        {
+            context.PreventNavigation();
+            queryParameters.Add(_requiredQueryParameters);
+
+            var uriBuilder = new UriBuilder(uri)
+            {
+                Query = queryParameters.ToString()
+            };
+
+            _navigationManager.NavigateTo(uriBuilder.Uri.ToString(), new NavigationOptions()
+            {
+                HistoryEntryState = context.HistoryEntryState,
+                ReplaceHistoryEntry = true,
+            });
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private void AssertInitialized()
+    {
+        if (!_isInitialized)
+        {
+            throw new InvalidOperationException($"The {nameof(VsCodeHelper)} has not been initialized.");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (!_isInitialized)
+        {
+            return;
+        }
+
+        _locationChangingRegistration.Dispose();
+    }
+}

--- a/blazorApp/Services/VsCodeHelper.cs
+++ b/blazorApp/Services/VsCodeHelper.cs
@@ -54,7 +54,11 @@ internal sealed class VsCodeHelper : IDisposable
 
         // VSCode navigates to /index.html by default, which will match the "not found" route
         // after Blazor starts up. So, we navigate to the home page immediately.
-        _navigationManager.NavigateTo($"/?{_requiredQueryParameters}");
+        // We replace the history entry so you can't navigate back to the "not found" state.
+        _navigationManager.NavigateTo($"/?{_requiredQueryParameters}", new NavigationOptions
+        {
+            ReplaceHistoryEntry = true,
+        });
 
         // VSCode reads query parameters from the URI to determine how to load resources. Since
         // navigations would remove that query string, we intercept all navigation attempts,
@@ -97,10 +101,9 @@ internal sealed class VsCodeHelper : IDisposable
                 Query = queryParameters.ToString()
             };
 
-            _navigationManager.NavigateTo(uriBuilder.Uri.ToString(), new NavigationOptions()
+            _navigationManager.NavigateTo(uriBuilder.Uri.ToString(), new NavigationOptions
             {
                 HistoryEntryState = context.HistoryEntryState,
-                ReplaceHistoryEntry = true,
             });
         }
 

--- a/blazorApp/Services/VsCodeHelper.cs
+++ b/blazorApp/Services/VsCodeHelper.cs
@@ -73,7 +73,7 @@ internal sealed class VsCodeHelper : IDisposable
         _isInitialized = true;
     }
 
-    public string AsWebViewUri(string relativeUri)
+    public string AsWebViewResourceFileUri(string relativeUri)
     {
         AssertInitialized();
         return Path.Combine(_localResourceRoot, relativeUri);

--- a/blazorApp/_Imports.razor
+++ b/blazorApp/_Imports.razor
@@ -7,4 +7,5 @@
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
 @using Microsoft.JSInterop
 @using blazorApp
+@using blazorApp.Services
 @using blazorApp.Shared

--- a/blazorApp/blazorApp.csproj
+++ b/blazorApp/blazorApp.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0-rc.2.22476.2" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -96,7 +96,7 @@ export function deactivate() {}
 	}
 
 	private _getHtmlForBlazorWebview() {
-		const basePath = path.join(this._extensionPath, BlazorPanel.appName, 'bin', 'debug', 'net6.0', 'publish', 'wwwroot') + "\\";
+		const basePath = path.join(this._extensionPath, BlazorPanel.appName, 'bin', 'debug', 'net7.0', 'publish', 'wwwroot') + "\\";
 		const baseUrl = this.buildWebViewUrl(basePath);
 
 		// Use a nonce to whitelist which scripts can be run
@@ -109,11 +109,11 @@ export function deactivate() {}
 				<meta charset="utf-8" />
 				<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 				<title>blazorApp</title>
-				<base href="${baseUrl}">
+				<base href="/">
 				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src https:; img-src vscode-resource: https: data:; script-src 'unsafe-inline' 'unsafe-eval' https:; style-src vscode-resource: 'unsafe-inline' http: https: data:; font-src https:">
-				<link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
-				<link href="css/app.css" rel="stylesheet" />
-				<link href="${BlazorPanel.appName+'.styles.css'}" rel="stylesheet" />
+				<link href="${baseUrl}css/bootstrap/bootstrap.min.css" rel="stylesheet" />
+				<link href="${baseUrl}css/app.css" rel="stylesheet" />
+				<link href="${baseUrl}${BlazorPanel.appName}.styles.css" rel="stylesheet" />
 			</head>
 			
 			<body>
@@ -123,16 +123,12 @@ export function deactivate() {}
 					<a href="" class="reload">Reload</a>
 					<a class="dismiss">🗙</a>
 				</div>
-				<script nonce="${nonce}" src="_framework/blazor.webassembly.js" autostart="false"></script>
-				<script nonce="${nonce}">
-
-					// WARNING - WORKAROUND NOT GUARANTEED TO WORK IN FUTURE
-					// Without this line of script, Blazor 6.0 (and likely 7.0) will through an exception on launch of the blazorApp, and fail to load properly.
-					// The Blazor team is looking at this problem, and will likely address in a future version of Blazor.
-					// Issue tracking this problem: https://github.com/dotnet/aspnetcore/issues/26790
-					Blazor._internal.navigationManager.getLocationHref = () => document.baseURI;
-					
-					Blazor.start();
+				<script nonce="${nonce}" src="${baseUrl}_framework/blazor.webassembly.js" autostart="false"></script>
+				<script>
+					window.getLocalResourceRoot = () => '${baseUrl}';
+					Blazor.start({
+						loadBootResource: (type, name, defaultUri, integrity) => \`${baseUrl}_framework/\${name}\`,
+					});
 				</script>
 			</body>
 			


### PR DESCRIPTION
### After these changes...
1. Navigations can be performed within the Blazor extension
2. Local static assets can be loaded in .NET (even after navigating)

### Summary of what changed:
* The base href is now "/":
  * Resources referenced in the static HTML in `extension.ts` should now use absolute URIs
  * Static asset paths in .NET should be converted to absolute URIs via `VsCodeHelper.AsWebViewUri(string relativePath)`
* A new `VsCodeHelper` service was added:
  * Adds custom navigation logic for VSCode support (details are documented in `VsCodeHelper.cs`)
  * Provides a helper to convert from relative URIs to the special VSCode absolute URIs for static assets
* Updated to .NET 7 RC2, which has navigation interception features needed to make this whole thing work nicely